### PR TITLE
Add support for Amazon Linux (under Amazon Lightsail)

### DIFF
--- a/tasks/install-amzn.yml
+++ b/tasks/install-amzn.yml
@@ -1,0 +1,11 @@
+
+- name: Install Amzn/2018 specific packages
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - epel-release
+
+- name: Set OS Version (Amzn/2018)
+  set_fact:
+    os_version: "Amzn/2018.03"

--- a/tasks/install-amzn.yml
+++ b/tasks/install-amzn.yml
@@ -8,4 +8,4 @@
 
 - name: Set OS Version (Amzn/2018)
   set_fact:
-    os_version: "Amzn/2018.03"
+    os_version: "amzn/2018.03"

--- a/tasks/install-centos.yml
+++ b/tasks/install-centos.yml
@@ -1,0 +1,11 @@
+
+- name: Install CentOS specific packages
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - epel-release
+
+- name: Set OS Version (CentOS)
+  set_fact:
+    os_version: "{{ ansible_facts['distribution'] | lower }}/{{ ansible_facts['distribution_major_version'] }}"

--- a/tasks/install-common.yml
+++ b/tasks/install-common.yml
@@ -1,0 +1,15 @@
+- name: Install necessary packages (both OSes)
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - python-setuptools
+    - python-pip
+    - openssh-server
+
+- name: Install required pip libraries
+  pip:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - urllib3

--- a/tasks/install-ubuntu.yml
+++ b/tasks/install-ubuntu.yml
@@ -1,0 +1,13 @@
+
+- name: Install Ubuntu specific packages
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - apt-utils
+  when: ansible_facts['distribution'] == 'Ubuntu'
+
+- name: Set OS Version (Ubuntu)
+  set_fact:
+    os_version: "{{ ansible_facts['distribution'] | lower }}/{{ ansible_facts['distribution_version'] }}"
+  when: ansible_facts['distribution'] == 'Ubuntu'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,52 +1,23 @@
 ---
 # tasks file for ansible-role-foxpass
-- name: Set OS Version (CentOS)
-  set_fact:
-    os_version: "{{ ansible_facts['distribution'] | lower }}/{{ ansible_facts['distribution_major_version'] }}"
-  when: ansible_facts['distribution'] == 'CentOS'
 
-- name: Set OS Version (Ubuntu)
-  set_fact:
-    os_version: "{{ ansible_facts['distribution'] | lower }}/{{ ansible_facts['distribution_version'] }}"
-  when: ansible_facts['distribution'] == 'Ubuntu'
+- include_tasks: install-centos.yml
+  when: ansible_os_family == 'CentOS'
+
+- include_tasks: install-ubuntu.yml
+  when: ansible_os_family == 'Ubuntu'
+
+# Specifically tested on Amazon Lightsail "amazon_linux_2018_03_0_2"
+- include_tasks: install-amzn.yml
+  when: ansible_os_family == 'Amazon' and ansible_facts['distribution_major_version'] == '2018'
+
+- include_tasks: install-common.yml
 
 - name: Download FoxPass setup script
   get_url:
     url: "https://raw.githubusercontent.com/foxpass/foxpass-setup/master/linux/{{ os_version }}/foxpass_setup.py"
     dest: /tmp/foxpass_setup.py
     mode: 0700
-
-- name: Install CentOS specific packages
-  package:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - epel-release
-  when: ansible_facts['distribution'] == 'CentOS'
-
-- name: Install Ubuntu specific packages
-  package:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - apt-utils
-  when: ansible_facts['distribution'] == 'Ubuntu'
-
-- name: Install necessary packages (both OSes)
-  package:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - python-setuptools
-    - python-pip
-    - openssh-server
-
-- name: Install required pip libraries
-  pip:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - urllib3
 
 - name: Run FoxPass setup script
   command: "python /tmp/foxpass_setup.py --base-dn {{ foxpass_base_dn }} --bind-user {{ foxpass_bind_user }} --bind-pw {{ foxpass_bind_pw }} --api-key {{ foxpass_api_key }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 
 # Specifically tested on Amazon Lightsail "amazon_linux_2018_03_0_2"
 - include_tasks: install-amzn.yml
-  when: ansible_os_family == 'Amazon' and ansible_facts['distribution_major_version'] == '2018'
+  when: ansible_facts['distribution'] == 'Amazon' and ansible_facts['distribution_major_version'] == '2018'
 
 - include_tasks: install-common.yml
 


### PR DESCRIPTION
- Break installers into specific include files for easier review
- Added support for Amazon Linux (specifically the Lightsail blueprint `amazon_linux_2018_03_0_2`).

This addresses/resolves issue #3 .